### PR TITLE
Use <q-args> instead of <args>.

### DIFF
--- a/plugin/macroscope.vim
+++ b/plugin/macroscope.vim
@@ -1,1 +1,1 @@
-command! -nargs=? Macroscope call macroscope#open(<args>)
+command! -nargs=? Macroscope call macroscope#open(<q-args>)


### PR DESCRIPTION
<q-args> quote the argument automatically. And then, we can use it without
quotation mark, like: `Macroscope q`.

Close #1