### PR TITLE
remove `*` autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ article](https://thoughtbot.com/blog/how-to-edit-an-existing-vim-macro) for the
   no register supplied).
 - Leaving the window will automatically update the macro with whatever was
   inside the `macroscope` window.
-- Alternatively, `s` in normal mode in the `macroscope` window to update the
-  macro.
 
 See the docs for configuration options.
 

--- a/autoload/macroscope.vim
+++ b/autoload/macroscope.vim
@@ -51,6 +51,7 @@ function! s:close_window(reg)
 endfunction
 
 function! s:update_macro(reg)
+  echo 'macroscope: macro in register ' . a:reg . ' updated!'
   execute 'normal! "' . a:reg . 'yy'
 endfunction
 
@@ -58,6 +59,5 @@ function! s:activate_autocmds(bufnr, reg)
   augroup macroscope_autohide
     autocmd!
     execute 'autocmd Winleave <buffer=' . a:bufnr . '> nested call <SID>close_window("'. a:reg . '")'
-    execute 'autocmd * <buffer=' . a:bufnr . '> nnoremap <buffer> s <SID>update_macro("' . a:reg . '")'
   augroup END
 endfunction

--- a/doc/macroscope.txt
+++ b/doc/macroscope.txt
@@ -1,4 +1,4 @@
-*macroscope.txt* Quick macro editing                                     v1.1.1
+*macroscope.txt* Quick macro editing                                     v2.0.0
 *Macroscope*
 
 ==============================================================================
@@ -58,9 +58,6 @@ This comes with no mappings out of the box, but feel free to add one like
 so: >
 
     nnoremap <leader>ms :Macroscope
-
-Buffer-local ~
-    s       Update the macro with the contents of the window.
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
- vim displays an error message if * autocmds are used
- add an echo message to confirm that the macro has been updated